### PR TITLE
Retinue Fixes

### DIFF
--- a/NEOW/common/buildings/00_CastleCulture.txt
+++ b/NEOW/common/buildings/00_CastleCulture.txt
@@ -734,51 +734,51 @@ castle = {
 	ca_culture_group_altaic_1 = {
 		desc = ca_culture_group_altaic_1_desc
 		potential = {
-			OR = { 
-				custom_tooltip = {
-					OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-					text = ALTAIC_BUT_NOT_JURCHEN_TT
-				}
-				
+			OR = {
+				culture = turkmen
+				culture = azerbaijani
+				culture = soitoskan
+				culture_group = kipchak
+				culture_group = karluk
+				culture_group = mongolic
 				has_building = ca_culture_group_altaic_1
 			}
+			Not = {culture = tatarian}
+			Not = {culture = bashkir}
+			Not = {culture = balkar}
+			Not = {culture = moghol}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 0 
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		prerequisites = { ca_wall_2 }
@@ -796,52 +796,52 @@ castle = {
 	ca_culture_group_altaic_2 = {
 		desc = ca_culture_group_altaic_1_desc
 		potential = {
-			OR = { 
-				custom_tooltip = {
-					OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-					text = ALTAIC_BUT_NOT_JURCHEN_TT
-				}
-				
+			OR = {
+				culture = turkmen
+				culture = azerbaijani
+				culture = soitoskan
+				culture_group = kipchak
+				culture_group = karluk
+				culture_group = mongolic
 				has_building = ca_culture_group_altaic_1
 				has_building = ca_culture_group_altaic_2
 			}
+			Not = {culture = tatarian}
+			Not = {culture = bashkir}
+			Not = {culture = balkar}
+			Not = {culture = moghol}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		trigger = { 
-			TECH_CASTLE_CONSTRUCTION = 1
+			TECH_CASTLE_CONSTRUCTION = 1 
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		upgrades_from = ca_culture_group_altaic_1
@@ -859,53 +859,53 @@ castle = {
 	ca_culture_group_altaic_3 = {
 		desc = ca_culture_group_altaic_1_desc
 		potential = {
-			OR = { 
-				custom_tooltip = {
-					OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-					text = ALTAIC_BUT_NOT_JURCHEN_TT
-				}
-				
+			OR = {
+				culture = turkmen
+				culture = azerbaijani
+				culture = soitoskan
+				culture_group = kipchak
+				culture_group = karluk
+				culture_group = mongolic
 				has_building = ca_culture_group_altaic_1
 				has_building = ca_culture_group_altaic_2
 				has_building = ca_culture_group_altaic_3
 			}
+			Not = {culture = tatarian}
+			Not = {culture = bashkir}
+			Not = {culture = balkar}
+			Not = {culture = moghol}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}					
-					
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		trigger = { 
-			TECH_CASTLE_CONSTRUCTION = 2
+			TECH_CASTLE_CONSTRUCTION = 2 
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		upgrades_from = ca_culture_group_altaic_2
@@ -923,54 +923,54 @@ castle = {
 	ca_culture_group_altaic_4 = {
 		desc = ca_culture_group_altaic_1_desc
 		potential = {
-			OR = { 
-				custom_tooltip = {
-					OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-					text = ALTAIC_BUT_NOT_JURCHEN_TT
-				}
-				
+			OR = {
+				culture = turkmen
+				culture = azerbaijani
+				culture = soitoskan
+				culture_group = kipchak
+				culture_group = karluk
+				culture_group = mongolic
 				has_building = ca_culture_group_altaic_1
 				has_building = ca_culture_group_altaic_2
 				has_building = ca_culture_group_altaic_3
 				has_building = ca_culture_group_altaic_4
 			}
+			Not = {culture = tatarian}
+			Not = {culture = bashkir}
+			Not = {culture = balkar}
+			Not = {culture = moghol}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		trigger = { 
-			TECH_CASTLE_CONSTRUCTION = 4
+			TECH_CASTLE_CONSTRUCTION = 4 
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-						culture_group = oghuz
-						culture_group = karluk
-						culture_group = mongolic
-						culture_group = iranian
-					}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		upgrades_from = ca_culture_group_altaic_3
@@ -1492,38 +1492,35 @@ castle = {
 		desc = ca_culture_turkish_1_desc
 		potential = {
 			OR = { 
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci
+				culture_group = oghuz
 				culture = rumca
 				has_building = ca_culture_turkish_1
 			}
+			Not = {culture = turkmen}
+			Not = {culture = azerbaijani}
+			Not = {culture = qashqai}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci
-				culture = rumca
+					culture_group = oghuz
+					culture = rumca
 				}
+				Not = {culture = turkmen}
+				Not = {culture = azerbaijani}
+				Not = {culture = qashqai}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 0 
 			ROOT = {
 				OR = {
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci
-				culture = rumca
+					culture_group = oghuz
+					culture = rumca
 				}
+				Not = {culture = turkmen}
+				Not = {culture = azerbaijani}
+				Not = {culture = qashqai}
 			}
 		}
 		prerequisites = { ca_wall_2 }
@@ -1539,39 +1536,36 @@ castle = {
 		desc = ca_culture_turkish_1_desc
 		potential = {
 			OR = { 
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci 
+				culture_group = oghuz
 				culture = rumca
 				has_building = ca_culture_turkish_1
 				has_building = ca_culture_turkish_2
 			}
+			Not = {culture = turkmen}
+			Not = {culture = azerbaijani}
+			Not = {culture = qashqai}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci
-				culture = rumca
+					culture_group = oghuz
+					culture = rumca
 				}
+				Not = {culture = turkmen}
+				Not = {culture = azerbaijani}
+				Not = {culture = qashqai}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 1
 			ROOT = {
 				OR = {
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci
-				culture = rumca
+					culture_group = oghuz
+					culture = rumca
 				}
+				Not = {culture = turkmen}
+				Not = {culture = azerbaijani}
+				Not = {culture = qashqai}
 			}
 		}
 		upgrades_from = ca_culture_turkish_1
@@ -1587,40 +1581,37 @@ castle = {
 		desc = ca_culture_turkish_1_desc
 		potential = {
 			OR = { 
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci 
+				culture_group = oghuz
 				culture = rumca
 				has_building = ca_culture_turkish_1
 				has_building = ca_culture_turkish_2
 				has_building = ca_culture_turkish_3
 			}
+			Not = {culture = turkmen}
+			Not = {culture = azerbaijani}
+			Not = {culture = qashqai}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci
-				culture = rumca
+					culture_group = oghuz
+					culture = rumca
 				}
+				Not = {culture = turkmen}
+				Not = {culture = azerbaijani}
+				Not = {culture = qashqai}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 2
 			ROOT = {
 				OR = {
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci
-				culture = rumca
+					culture_group = oghuz
+					culture = rumca
 				}
+				Not = {culture = turkmen}
+				Not = {culture = azerbaijani}
+				Not = {culture = qashqai}
 			}
 		}
 		upgrades_from = ca_culture_turkish_2
@@ -1636,41 +1627,38 @@ castle = {
 		desc = ca_culture_turkish_4_desc
 		potential = {
 			OR = { 
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci
+				culture_group = oghuz
 				culture = rumca
 				has_building = ca_culture_turkish_1
 				has_building = ca_culture_turkish_2
 				has_building = ca_culture_turkish_3
 				has_building = ca_culture_turkish_4
 			}
+			Not = {culture = turkmen}
+			Not = {culture = azerbaijani}
+			Not = {culture = qashqai}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci
-				culture = rumca
+					culture_group = oghuz
+					culture = rumca
 				}
+				Not = {culture = turkmen}
+				Not = {culture = azerbaijani}
+				Not = {culture = qashqai}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 3
 			ROOT = {
 				OR = {
-				culture = turkish
-				culture = elbistanli
-				culture = egeli
-				culture = kapadokyali
-				culture = karadenizci
-				culture = rumca
+					culture_group = oghuz
+					culture = rumca
 				}
+				Not = {culture = turkmen}
+				Not = {culture = azerbaijani}
+				Not = {culture = qashqai}
 			}
 		}
 		upgrades_from = ca_culture_turkish_3
@@ -2119,6 +2107,8 @@ castle = {
 			OR = {
 				culture_group = caucasian
 				culture_group = armenian_group
+				culture = alan
+				culture = balkar
 				has_building = ca_culture_chechen_1				
 			}
 		}
@@ -2127,6 +2117,8 @@ castle = {
 				OR = {
 					culture_group = caucasian
 					culture_group = armenian_group
+					culture = alan
+					culture = balkar
 				}
 			}
 		}
@@ -2136,6 +2128,8 @@ castle = {
 				OR = {
 					culture_group = caucasian
 					culture_group = armenian_group
+					culture = alan
+					culture = balkar
 				}
 			}
 		}
@@ -2154,6 +2148,8 @@ castle = {
 			OR = {
 				culture_group = caucasian
 				culture_group = armenian_group
+				culture = alan
+				culture = balkar
 				has_building = ca_culture_chechen_1
 				has_building = ca_culture_chechen_2
 			}
@@ -2163,6 +2159,8 @@ castle = {
 				OR = {
 					culture_group = caucasian
 					culture_group = armenian_group
+					culture = alan
+					culture = balkar
 				}
 			}
 		}
@@ -2172,6 +2170,8 @@ castle = {
 				OR = {
 					culture_group = caucasian
 					culture_group = armenian_group
+					culture = alan
+					culture = balkar
 				}
 			}
 		}
@@ -2190,6 +2190,8 @@ castle = {
 			OR = {
 				culture_group = caucasian
 				culture_group = armenian_group
+				culture = alan
+				culture = balkar
 				has_building = ca_culture_chechen_1
 				has_building = ca_culture_chechen_2
 				has_building = ca_culture_chechen_3
@@ -2200,6 +2202,8 @@ castle = {
 				OR = {
 					culture_group = caucasian
 					culture_group = armenian_group
+					culture = alan
+					culture = balkar
 				}
 			}
 		}
@@ -2209,6 +2213,8 @@ castle = {
 				OR = {
 					culture_group = caucasian
 					culture_group = armenian_group
+					culture = alan
+					culture = balkar
 				}
 			}
 		}
@@ -2227,6 +2233,8 @@ castle = {
 			OR = {
 				culture_group = caucasian
 				culture_group = armenian_group
+				culture = alan
+				culture = balkar
 				has_building = ca_culture_chechen_1
 				has_building = ca_culture_chechen_2
 				has_building = ca_culture_chechen_3
@@ -2238,6 +2246,8 @@ castle = {
 				OR = {
 					culture_group = caucasian
 					culture_group = armenian_group
+					culture = alan
+					culture = balkar
 				}
 			}
 		}
@@ -2247,6 +2257,8 @@ castle = {
 				OR = {
 					culture_group = caucasian
 					culture_group = armenian_group
+					culture = alan
+					culture = balkar
 				}
 			}
 		}
@@ -2267,8 +2279,10 @@ castle = {
 			OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2280,8 +2294,10 @@ castle = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2294,8 +2310,10 @@ castle = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2317,8 +2335,10 @@ castle = {
 			OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2331,8 +2351,10 @@ castle = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2345,8 +2367,10 @@ castle = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2368,8 +2392,10 @@ castle = {
 			OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2383,8 +2409,10 @@ castle = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2397,8 +2425,10 @@ castle = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2420,8 +2450,10 @@ castle = {
 			OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2438,6 +2470,7 @@ castle = {
 				culture_group = east_slavic
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2450,8 +2483,10 @@ castle = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2635,7 +2670,7 @@ castle = {
 			OR = { 
 				culture = hungarian
 				culture_group = west_slavic
-				culture_group = far_west_indo_aryan_group
+				culture = romani
 				culture = wallachian
 				culture = transylvanian
 				has_building = ca_culture_hungarian_1
@@ -2646,7 +2681,7 @@ castle = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2658,7 +2693,7 @@ castle = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2679,7 +2714,7 @@ castle = {
 			OR = { 
 				culture = hungarian
 				culture_group = west_slavic
-				culture_group = far_west_indo_aryan_group
+				culture = romani
 				culture = wallachian
 				culture = transylvanian
 				has_building = ca_culture_hungarian_1
@@ -2691,7 +2726,7 @@ castle = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2703,7 +2738,7 @@ castle = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2724,7 +2759,7 @@ castle = {
 			OR = { 
 				culture = hungarian
 				culture_group = west_slavic
-				culture_group = far_west_indo_aryan_group
+				culture = romani
 				culture = wallachian
 				culture = transylvanian
 				has_building = ca_culture_hungarian_1
@@ -2737,7 +2772,7 @@ castle = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2749,7 +2784,7 @@ castle = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2770,7 +2805,7 @@ castle = {
 			OR = { 
 				culture = hungarian
 				culture_group = west_slavic
-				culture_group = far_west_indo_aryan_group
+				culture = romani
 				culture = wallachian
 				culture = transylvanian
 				has_building = ca_culture_hungarian_1
@@ -2784,7 +2819,7 @@ castle = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2796,7 +2831,7 @@ castle = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2823,6 +2858,7 @@ castle = {
 				culture_group = eastern_sudanic
 				culture_group = abbala_arabic
 				culture_group = saharan
+				culture = domari
 				has_building = ca_culture_group_arabic_1
 			}
 			NOT = {culture = amriqi}			
@@ -2836,6 +2872,7 @@ castle = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}			
@@ -2850,6 +2887,7 @@ castle = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2873,6 +2911,7 @@ castle = {
 				culture_group = eastern_sudanic
 				culture_group = abbala_arabic
 				culture_group = saharan
+				culture = domari
 				has_building = ca_culture_group_arabic_1
 				has_building = ca_culture_group_arabic_2
 			}
@@ -2887,6 +2926,7 @@ castle = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2901,6 +2941,7 @@ castle = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2924,6 +2965,7 @@ castle = {
 				culture_group = eastern_sudanic
 				culture_group = abbala_arabic
 				culture_group = saharan
+				culture = domari
 				has_building = ca_culture_group_arabic_1
 				has_building = ca_culture_group_arabic_2
 				has_building = ca_culture_group_arabic_3
@@ -2939,6 +2981,7 @@ castle = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2953,6 +2996,7 @@ castle = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2976,6 +3020,7 @@ castle = {
 				culture_group = eastern_sudanic
 				culture_group = abbala_arabic
 				culture_group = saharan
+				culture = domari
 				has_building = ca_culture_group_arabic_1
 				has_building = ca_culture_group_arabic_2
 				has_building = ca_culture_group_arabic_3
@@ -2992,6 +3037,7 @@ castle = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -3006,6 +3052,7 @@ castle = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -3025,41 +3072,44 @@ castle = {
 		desc = ca_culture_group_byzantine_1_desc
 		potential = {
 			OR = {
-				AND = {
-					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+				culture_group = byzantine
+				culture_group = iranian
 				culture = aromanian
+				culture = qashqai
+				culture = moghol
+				culture = brahui
 				has_building = ca_culture_group_byzantine_1
 			}
+			NOT = {culture = rumca}
+			NOT = {culture = alan}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-					AND = {
-						culture_group = byzantine
-						NOT = {
-							culture = rumca
-						}
-					}
+					culture_group = byzantine
+					culture_group = iranian
 					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
 				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		trigger = {
 			TECH_CASTLE_CONSTRUCTION = 0 
 			ROOT = {
 				OR = {
-				AND = {
 					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+					culture_group = iranian
 					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
 				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		prerequisites = { ca_wall_2 }
@@ -3076,43 +3126,46 @@ castle = {
 	ca_culture_group_byzantine_2 = {
 		desc = ca_culture_group_byzantine_1_desc
 		potential = {
-			OR = { 
-				AND = {
-					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+			OR = {
+				culture_group = byzantine
+				culture_group = iranian
 				culture = aromanian
+				culture = qashqai
+				culture = moghol
+				culture = brahui
 				has_building = ca_culture_group_byzantine_1
-				has_building = ca_culture_group_byzantine_2 
+				has_building = ca_culture_group_byzantine_2
 			}
+			NOT = {culture = rumca}
+			NOT = {culture = alan}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-				AND = {
 					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+					culture_group = iranian
 					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
 				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 1
 			ROOT = {
 				OR = {
-				AND = {
 					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+					culture_group = iranian
 					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
 				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		upgrades_from = ca_culture_group_byzantine_1
@@ -3129,44 +3182,47 @@ castle = {
 	ca_culture_group_byzantine_3 = {
 		desc = ca_culture_group_byzantine_1_desc
 		potential = {
-			OR = { 
-				AND = {
-					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+			OR = {
+				culture_group = byzantine
+				culture_group = iranian
 				culture = aromanian
+				culture = qashqai
+				culture = moghol
+				culture = brahui
 				has_building = ca_culture_group_byzantine_1
 				has_building = ca_culture_group_byzantine_2
 				has_building = ca_culture_group_byzantine_3
 			}
+			NOT = {culture = rumca}
+			NOT = {culture = alan}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-				AND = {
 					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+					culture_group = iranian
 					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
 				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 2
 			ROOT = {
 				OR = {
-				AND = {
 					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+					culture_group = iranian
 					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
 				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		upgrades_from = ca_culture_group_byzantine_2
@@ -3183,45 +3239,48 @@ castle = {
 	ca_culture_group_byzantine_4 = {
 		desc = ca_culture_group_byzantine_1_desc
 		potential = {
-			OR = { 
-				AND = {
-					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+			OR = {
+				culture_group = byzantine
+				culture_group = iranian
 				culture = aromanian
+				culture = qashqai
+				culture = moghol
+				culture = brahui
 				has_building = ca_culture_group_byzantine_1
 				has_building = ca_culture_group_byzantine_2
 				has_building = ca_culture_group_byzantine_3
 				has_building = ca_culture_group_byzantine_4
 			}
+			NOT = {culture = rumca}
+			NOT = {culture = alan}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-				AND = {
 					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+					culture_group = iranian
 					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
 				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 4
 			ROOT = {
 				OR = {
-				AND = {
 					culture_group = byzantine
-					NOT = {
-						culture = rumca
-					}
-				}
+					culture_group = iranian
 					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
 				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		upgrades_from = ca_culture_group_byzantine_3
@@ -4880,16 +4939,14 @@ castle = {
 				culture_group = north_west_indo_aryan_group
 				culture_group = eastern_indo_aryan_group
 				culture_group = central_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
 				culture_group = east_asian_group
 				has_building = ca_culture_indian_1
 			}
-			NOR = {
-				culture = romani
-				culture = domari
-			}
+			Not = {culture = brahui}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -4902,12 +4959,10 @@ castle = {
 					culture_group = northern_dravidian_group
 					culture_group = eastern_dravidian_group
 					culture_group = southern_dravidian_group
+					culture = angrezi
 					culture_group = east_asian_group
 				}
-				NOR = {
-					culture = romani
-					culture = domari
-				}
+				Not = {culture = brahui}
 			}
 		}
 		trigger = { 
@@ -4922,12 +4977,10 @@ castle = {
 					culture_group = northern_dravidian_group
 					culture_group = eastern_dravidian_group
 					culture_group = southern_dravidian_group
+					culture = angrezi
 					culture_group = east_asian_group
 				}
-				NOR = {
-					culture = romani
-					culture = domari
-				}
+				Not = {culture = brahui}
 			}
 		}
 		prerequisites = { ca_wall_2 }
@@ -4948,17 +5001,15 @@ castle = {
 				culture_group = north_west_indo_aryan_group
 				culture_group = eastern_indo_aryan_group
 				culture_group = central_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
 				culture_group = east_asian_group
 				has_building = ca_culture_indian_1
 				has_building = ca_culture_indian_2
 			}
-			NOR = {
-				culture = romani
-				culture = domari
-			}
+			Not = {culture = brahui}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -4971,12 +5022,10 @@ castle = {
 					culture_group = northern_dravidian_group
 					culture_group = eastern_dravidian_group
 					culture_group = southern_dravidian_group
+					culture = angrezi
 					culture_group = east_asian_group
 				}
-				NOR = {
-					culture = romani
-					culture = domari
-				}
+				Not = {culture = brahui}
 			}
 		}
 		trigger = { 
@@ -4991,12 +5040,10 @@ castle = {
 					culture_group = northern_dravidian_group
 					culture_group = eastern_dravidian_group
 					culture_group = southern_dravidian_group
+					culture = angrezi
 					culture_group = east_asian_group
 				}
-				NOR = {
-					culture = romani
-					culture = domari
-				}
+				Not = {culture = brahui}
 			}
 		}
 		upgrades_from = ca_culture_indian_1
@@ -5018,18 +5065,16 @@ castle = {
 				culture_group = north_west_indo_aryan_group
 				culture_group = eastern_indo_aryan_group
 				culture_group = central_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
 				culture_group = east_asian_group
 				has_building = ca_culture_indian_1
 				has_building = ca_culture_indian_2
 				has_building = ca_culture_indian_3
 			}
-			NOR = {
-				culture = romani
-				culture = domari
-			}
+			Not = {culture = brahui}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -5042,12 +5087,10 @@ castle = {
 					culture_group = northern_dravidian_group
 					culture_group = eastern_dravidian_group
 					culture_group = southern_dravidian_group
+					culture = angrezi
 					culture_group = east_asian_group
 				}
-				NOR = {
-					culture = romani
-					culture = domari
-				}
+				Not = {culture = brahui}
 			}
 		}
 		trigger = { 
@@ -5062,12 +5105,10 @@ castle = {
 					culture_group = northern_dravidian_group
 					culture_group = eastern_dravidian_group
 					culture_group = southern_dravidian_group
+					culture = angrezi
 					culture_group = east_asian_group
 				}
-				NOR = {
-					culture = romani
-					culture = domari
-				}
+				Not = {culture = brahui}
 			}
 		}
 		upgrades_from = ca_culture_indian_2
@@ -5089,19 +5130,17 @@ castle = {
 				culture_group = north_west_indo_aryan_group
 				culture_group = eastern_indo_aryan_group
 				culture_group = central_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
 				culture_group = east_asian_group
 				has_building = ca_culture_indian_1
 				has_building = ca_culture_indian_2
 				has_building = ca_culture_indian_3
 				has_building = ca_culture_indian_4
 			}
-			NOR = {
-				culture = romani
-				culture = domari
-			}
+				Not = {culture = brahui}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -5114,12 +5153,10 @@ castle = {
 					culture_group = northern_dravidian_group
 					culture_group = eastern_dravidian_group
 					culture_group = southern_dravidian_group
+					culture = angrezi
 					culture_group = east_asian_group
 				}
-				NOR = {
-					culture = romani
-					culture = domari
-				}
+				Not = {culture = brahui}
 			}
 		}
 		trigger = { 
@@ -5134,12 +5171,10 @@ castle = {
 					culture_group = northern_dravidian_group
 					culture_group = eastern_dravidian_group
 					culture_group = southern_dravidian_group
+					culture = angrezi
 					culture_group = east_asian_group
 				}
-				NOR = {
-					culture = romani
-					culture = domari
-				}
+				Not = {culture = brahui}
 			}
 		}
 		upgrades_from = ca_culture_indian_3
@@ -7275,6 +7310,7 @@ castle = {
 				culture = assyrian
 				culture = aramaic
 				culture = babylonian
+				culture = mandaeans
 				has_building = ca_culture_assyrian_1
 			}
 		}
@@ -7284,6 +7320,7 @@ castle = {
 					culture = assyrian
 					culture = aramaic
 					culture = babylonian
+					culture = mandaeans
 				}
 			}
 		} 
@@ -7294,6 +7331,7 @@ castle = {
 					culture = assyrian
 					culture = aramaic
 					culture = babylonian
+					culture = mandaeans
 				}
 			}
 		}
@@ -7313,6 +7351,7 @@ castle = {
 				culture = assyrian
 				culture = aramaic
 				culture = babylonian
+				culture = mandaeans
 				has_building = ca_culture_assyrian_1
 				has_building = ca_culture_assyrian_2
 			}
@@ -7323,6 +7362,7 @@ castle = {
 					culture = assyrian
 					culture = aramaic
 					culture = babylonian
+					culture = mandaeans
 				}
 			}
 		} 
@@ -7333,6 +7373,7 @@ castle = {
 					culture = assyrian
 					culture = aramaic
 					culture = babylonian
+					culture = mandaeans
 				}
 			}
 		}
@@ -7352,6 +7393,7 @@ castle = {
 				culture = assyrian
 				culture = aramaic
 				culture = babylonian
+				culture = mandaeans
 				has_building = ca_culture_assyrian_1
 				has_building = ca_culture_assyrian_2
 				has_building = ca_culture_assyrian_3
@@ -7363,6 +7405,7 @@ castle = {
 					culture = assyrian
 					culture = aramaic
 					culture = babylonian
+					culture = mandaeans
 				}
 			}
 		} 
@@ -7373,6 +7416,7 @@ castle = {
 					culture = assyrian
 					culture = aramaic
 					culture = babylonian
+					culture = mandaeans
 				}
 			}
 		}
@@ -7392,6 +7436,7 @@ castle = {
 				culture = assyrian
 				culture = aramaic
 				culture = babylonian
+				culture = mandaeans
 				has_building = ca_culture_assyrian_1
 				has_building = ca_culture_assyrian_2
 				has_building = ca_culture_assyrian_3
@@ -7404,6 +7449,7 @@ castle = {
 					culture = assyrian
 					culture = aramaic
 					culture = babylonian
+					culture = mandaeans
 				}
 			}
 		} 
@@ -7414,6 +7460,7 @@ castle = {
 					culture = assyrian
 					culture = aramaic
 					culture = babylonian
+					culture = mandaeans
 				}
 			}
 		}

--- a/NEOW/common/buildings/00_tribalCulture.txt
+++ b/NEOW/common/buildings/00_tribalCulture.txt
@@ -798,7 +798,7 @@ tribal = {
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 1
-			RROOT = {
+			ROOT = {
 				OR = {
 					culture = scottish
 					culture = oglallan
@@ -876,6 +876,13 @@ tribal = {
 				culture_group = finno_ugric
 				has_building = tb_culture_group_baltic_1
 			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
+			}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -883,6 +890,13 @@ tribal = {
 					culture_group = baltic
 					culture_group = finno_ugric
 				}
+			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
 			}
 		}
 		trigger = { 
@@ -892,6 +906,13 @@ tribal = {
 					culture_group = baltic
 					culture_group = finno_ugric
 				}
+			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
 			}
 		}
 		
@@ -912,6 +933,13 @@ tribal = {
 				has_building = tb_culture_group_baltic_1
 				has_building = tb_culture_group_baltic_2
 			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
+			}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -919,6 +947,13 @@ tribal = {
 					culture_group = baltic
 					culture_group = finno_ugric
 				}
+			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
 			}
 		}
 		trigger = { 
@@ -928,6 +963,13 @@ tribal = {
 					culture_group = baltic
 					culture_group = finno_ugric
 				}
+			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
 			}
 		}
 		upgrades_from = tb_culture_group_baltic_1
@@ -951,6 +993,13 @@ tribal = {
 				has_building = tb_culture_group_baltic_2
 				has_building = tb_culture_group_baltic_3
 			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
+			}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -958,6 +1007,13 @@ tribal = {
 					culture_group = baltic
 					culture_group = finno_ugric
 				}
+			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
 			}
 		}
 		trigger = { 
@@ -967,6 +1023,13 @@ tribal = {
 					culture_group = baltic
 					culture_group = finno_ugric
 				}
+			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
 			}
 		}
 		upgrades_from = tb_culture_group_baltic_2
@@ -989,6 +1052,13 @@ tribal = {
 				has_building = tb_culture_group_baltic_3
 				has_building = tb_culture_group_baltic_4
 			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
+			}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -996,6 +1066,13 @@ tribal = {
 					culture_group = baltic
 					culture_group = finno_ugric
 				}
+			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
 			}
 		}
 		trigger = { 
@@ -1005,6 +1082,13 @@ tribal = {
 					culture_group = baltic
 					culture_group = finno_ugric
 				}
+			}
+			NOT = {
+				OR = {
+					culture = khanty
+					culture = komi
+					culture = lytsvin
+				}	
 			}
 		}
 		upgrades_from = tb_culture_group_baltic_3
@@ -1024,71 +1108,50 @@ tribal = {
 		desc = ca_culture_group_altaic_1_desc
 		potential = {
 			OR = {
-				custom_tooltip = {
-					OR = {
-						culture = turkish
-						culture = pecheneg
-						culture = cuman
-						culture = khazar
-						culture = bolghar
-						culture = avar
-						culture = karluk
-						culture = kirghiz
-						culture = uyghur
-						culture = mongol
-						culture = khitan
-					}
-					text = ALTAIC_BUT_NOT_JURCHEN_TT
-				}
-				culture_group = iranian
+				culture = turkmen
+				culture = azerbaijani
+				culture = soitoskan
+				culture_group = kipchak
+				culture_group = karluk
+				culture_group = mongolic
 				has_building = tb_culture_group_altaic_1
 			}
+			Not = {culture = tatarian}
+			Not = {culture = bashkir}
+			Not = {culture = balkar}
+			Not = {culture = moghol}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-							culture = turkish
-							culture = pecheneg
-							culture = cuman
-							culture = khazar
-							culture = bolghar
-							culture = avar
-							culture = karluk
-							culture = kirghiz
-							culture = uyghur
-							culture = mongol
-							culture = khitan
-						}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					culture_group = iranian
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 0 
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-							culture = turkish
-							culture = pecheneg
-							culture = cuman
-							culture = khazar
-							culture = bolghar
-							culture = avar
-							culture = karluk
-							culture = kirghiz
-							culture = uyghur
-							culture = mongol
-							culture = khitan
-						}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					culture_group = iranian
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		
@@ -1105,73 +1168,52 @@ tribal = {
 	tb_culture_group_altaic_2 = {
 		desc = ca_culture_group_altaic_1_desc
 		potential = {
-			OR = { 
-				custom_tooltip = {
-					OR = {
-						culture = turkish
-						culture = pecheneg
-						culture = cuman
-						culture = khazar
-						culture = bolghar
-						culture = avar
-						culture = karluk
-						culture = kirghiz
-						culture = uyghur
-						culture = mongol
-						culture = khitan
-					}
-					text = ALTAIC_BUT_NOT_JURCHEN_TT
-				}
-				culture_group = iranian
+			OR = {
+				culture = turkmen
+				culture = azerbaijani
+				culture = soitoskan
+				culture_group = kipchak
+				culture_group = karluk
+				culture_group = mongolic
 				has_building = tb_culture_group_altaic_1
 				has_building = tb_culture_group_altaic_2
 			}
+			Not = {culture = tatarian}
+			Not = {culture = bashkir}
+			Not = {culture = balkar}
+			Not = {culture = moghol}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-							culture = turkish
-							culture = pecheneg
-							culture = cuman
-							culture = khazar
-							culture = bolghar
-							culture = avar
-							culture = karluk
-							culture = kirghiz
-							culture = uyghur
-							culture = mongol
-							culture = khitan
-						}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					culture_group = iranian
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 0 
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-							culture = turkish
-							culture = pecheneg
-							culture = cuman
-							culture = khazar
-							culture = bolghar
-							culture = avar
-							culture = karluk
-							culture = kirghiz
-							culture = uyghur
-							culture = mongol
-							culture = khitan
-						}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					culture_group = iranian
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		upgrades_from = tb_culture_group_altaic_1
@@ -1191,73 +1233,52 @@ tribal = {
 		desc = ca_culture_group_altaic_1_desc
 		potential = {
 			OR = {
-				custom_tooltip = {
-					OR = {
-						culture = turkish
-						culture = pecheneg
-						culture = cuman
-						culture = khazar
-						culture = bolghar
-						culture = avar
-						culture = karluk
-						culture = kirghiz
-						culture = uyghur
-						culture = mongol
-						culture = khitan
-					}
-					text = ALTAIC_BUT_NOT_JURCHEN_TT
-				}
-				culture_group = iranian
+				culture = turkmen
+				culture = azerbaijani
+				culture = soitoskan
+				culture_group = kipchak
+				culture_group = karluk
+				culture_group = mongolic
 				has_building = tb_culture_group_altaic_1
 				has_building = tb_culture_group_altaic_2
 				has_building = tb_culture_group_altaic_3
 			}
+			Not = {culture = tatarian}
+			Not = {culture = bashkir}
+			Not = {culture = balkar}
+			Not = {culture = moghol}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-							culture = turkish
-							culture = pecheneg
-							culture = cuman
-							culture = khazar
-							culture = bolghar
-							culture = avar
-							culture = karluk
-							culture = kirghiz
-							culture = uyghur
-							culture = mongol
-							culture = khitan
-						}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					culture_group = iranian
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 1
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-							culture = turkish
-							culture = pecheneg
-							culture = cuman
-							culture = khazar
-							culture = bolghar
-							culture = avar
-							culture = karluk
-							culture = kirghiz
-							culture = uyghur
-							culture = mongol
-							culture = khitan
-						}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					culture_group = iranian
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		upgrades_from = tb_culture_group_altaic_2
@@ -1275,74 +1296,53 @@ tribal = {
 		desc = ca_culture_group_altaic_1_desc
 		potential = {
 			OR = {
-				custom_tooltip = {
-					OR = {
-						culture = turkish
-						culture = pecheneg
-						culture = cuman
-						culture = khazar
-						culture = bolghar
-						culture = avar
-						culture = karluk
-						culture = kirghiz
-						culture = uyghur
-						culture = mongol
-						culture = khitan
-					}
-					text = ALTAIC_BUT_NOT_JURCHEN_TT
-				}
-				culture_group = iranian
+				culture = turkmen
+				culture = azerbaijani
+				culture = soitoskan
+				culture_group = kipchak
+				culture_group = karluk
+				culture_group = mongolic
 				has_building = tb_culture_group_altaic_1
 				has_building = tb_culture_group_altaic_2
 				has_building = tb_culture_group_altaic_3
 				has_building = tb_culture_group_altaic_4
 			}
+			Not = {culture = tatarian}
+			Not = {culture = bashkir}
+			Not = {culture = balkar}
+			Not = {culture = moghol}
 		}
 		is_active_trigger = {
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-							culture = turkish
-							culture = pecheneg
-							culture = cuman
-							culture = khazar
-							culture = bolghar
-							culture = avar
-							culture = karluk
-							culture = kirghiz
-							culture = uyghur
-							culture = mongol
-							culture = khitan
-						}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					culture_group = iranian
+					culture = turkmen
+					culture = azerbaijani
+					culture = soitoskan
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 1
 			ROOT = {
 				OR = {
-					custom_tooltip = {
-						OR = {
-							culture = turkish
-							culture = pecheneg
-							culture = cuman
-							culture = khazar
-							culture = bolghar
-							culture = avar
-							culture = karluk
-							culture = kirghiz
-							culture = uyghur
-							culture = mongol
-							culture = khitan
-						}
-						text = ALTAIC_BUT_NOT_JURCHEN_TT
-					}
-					culture_group = iranian
+					culture = turkmen
+					culture = soitoskan
+					culture = azerbaijani
+					culture_group = kipchak
+					culture_group = karluk
+					culture_group = mongolic
 				}
+				Not = {culture = tatarian}
+				Not = {culture = bashkir}
+				Not = {culture = balkar}
+				Not = {culture = moghol}
 			}
 		}
 		upgrades_from = tb_culture_group_altaic_3
@@ -1874,8 +1874,10 @@ tribal = {
 			OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -1887,8 +1889,10 @@ tribal = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -1901,8 +1905,10 @@ tribal = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -1924,8 +1930,10 @@ tribal = {
 			OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -1938,8 +1946,10 @@ tribal = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -1952,8 +1962,10 @@ tribal = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -1977,8 +1989,10 @@ tribal = {
 			OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir 
@@ -1992,8 +2006,10 @@ tribal = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2006,8 +2022,10 @@ tribal = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2029,8 +2047,10 @@ tribal = {
 			OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2045,8 +2065,10 @@ tribal = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2059,8 +2081,10 @@ tribal = {
 				OR = { 
 				culture_group = central_slavic
 				culture_group = east_slavic
+				culture_group = oghur
 				culture = lytsvin
 				culture = adessite
+				culture = sazzac
 				culture = gottonsk
 				culture = tatarian
 				culture = bashkir
@@ -2250,7 +2274,7 @@ tribal = {
 			OR = {
 				culture = hungarian
 				culture_group = west_slavic
-				culture_group = far_west_indo_aryan_group
+				culture = romani
 				culture = wallachian
 				culture = transylvanian
 				has_building = tb_culture_hungarian_1
@@ -2261,7 +2285,7 @@ tribal = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2273,7 +2297,7 @@ tribal = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2294,7 +2318,7 @@ tribal = {
 			OR = {
 				culture = hungarian
 				culture_group = west_slavic
-				culture_group = far_west_indo_aryan_group
+				culture = romani
 				culture = wallachian
 				culture = transylvanian
 				has_building = tb_culture_hungarian_1
@@ -2306,7 +2330,7 @@ tribal = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2318,7 +2342,7 @@ tribal = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2341,7 +2365,7 @@ tribal = {
 			OR = {
 				culture = hungarian
 				culture_group = west_slavic
-				culture_group = far_west_indo_aryan_group
+				culture = romani
 				culture = wallachian
 				culture = transylvanian
 				has_building = tb_culture_hungarian_1
@@ -2354,7 +2378,7 @@ tribal = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2366,7 +2390,7 @@ tribal = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2387,7 +2411,7 @@ tribal = {
 			OR = {
 				culture = hungarian
 				culture_group = west_slavic
-				culture_group = far_west_indo_aryan_group
+				culture = romani
 				culture = wallachian
 				culture = transylvanian
 				has_building = tb_culture_hungarian_1
@@ -2401,7 +2425,7 @@ tribal = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2413,7 +2437,7 @@ tribal = {
 				OR = {
 					culture_group = west_slavic
 					culture = hungarian
-					culture_group = far_west_indo_aryan_group
+					culture = romani
 					culture = wallachian
 					culture = transylvanian
 				}
@@ -2442,6 +2466,7 @@ tribal = {
 				culture_group = eastern_sudanic
 				culture_group = abbala_arabic
 				culture_group = saharan
+				culture = domari
 				has_building = tb_culture_group_arabic_1
 			}
 			NOT = {culture = amriqi}
@@ -2455,6 +2480,7 @@ tribal = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2469,6 +2495,7 @@ tribal = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2492,6 +2519,7 @@ tribal = {
 				culture_group = eastern_sudanic
 				culture_group = abbala_arabic
 				culture_group = saharan
+				culture = domari
 				has_building = tb_culture_group_arabic_1
 				has_building = tb_culture_group_arabic_2
 			}
@@ -2505,6 +2533,7 @@ tribal = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2519,6 +2548,7 @@ tribal = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2544,6 +2574,7 @@ tribal = {
 				culture_group = eastern_sudanic
 				culture_group = abbala_arabic
 				culture_group = saharan
+				culture = domari
 				has_building = tb_culture_group_arabic_1
 				has_building = tb_culture_group_arabic_2
 				has_building = tb_culture_group_arabic_3
@@ -2559,6 +2590,7 @@ tribal = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2573,6 +2605,7 @@ tribal = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2596,6 +2629,7 @@ tribal = {
 				culture_group = eastern_sudanic
 				culture_group = abbala_arabic
 				culture_group = saharan
+				culture = domari
 				has_building = tb_culture_group_arabic_1
 				has_building = tb_culture_group_arabic_2
 				has_building = tb_culture_group_arabic_3
@@ -2612,6 +2646,7 @@ tribal = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2626,6 +2661,7 @@ tribal = {
 					culture_group = eastern_sudanic
 					culture_group = abbala_arabic
 					culture_group = saharan
+					culture = domari
 				}
 				NOT = {culture = amriqi}
 			}
@@ -2646,23 +2682,45 @@ tribal = {
 	tb_culture_group_byzantine_1 = {
 		desc = tb_culture_group_byzantine_1_desc
 		potential = {
-			OR = { 
-				AND = {
-					culture_group = byzantine
-					NOT = { culture = coptic }
-				}
+			OR = {
+				culture_group = byzantine
+				culture_group = iranian
+				culture = aromanian
+				culture = qashqai
+				culture = moghol
+				culture = brahui
 				has_building = tb_culture_group_byzantine_1
 			}
+			NOT = {culture = rumca}
+			NOT = {culture = alan}
 		}
 		is_active_trigger = {
 			ROOT = {
-				culture_group = byzantine
+				OR = {
+					culture_group = byzantine
+					culture_group = iranian
+					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
+				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 0 
 			ROOT = {
-				culture_group = byzantine
+				OR = {
+					culture_group = byzantine
+					culture_group = iranian
+					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
+				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		
@@ -2679,24 +2737,46 @@ tribal = {
 	tb_culture_group_byzantine_2 = {
 		desc = tb_culture_group_byzantine_1_desc
 		potential = {
-			OR = { 
-				AND = {
-					culture_group = byzantine
-					NOT = { culture = coptic }
-				}
+			OR = {
+				culture_group = byzantine
+				culture_group = iranian
+				culture = aromanian
+				culture = qashqai
+				culture = moghol
+				culture = brahui
 				has_building = tb_culture_group_byzantine_1
 				has_building = tb_culture_group_byzantine_2
 			}
+			NOT = {culture = rumca}
+			NOT = {culture = alan}
 		}
 		is_active_trigger = {
 			ROOT = {
-				culture_group = byzantine
+				OR = {
+					culture_group = byzantine
+					culture_group = iranian
+					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
+				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 0 
 			ROOT = {
-				culture_group = byzantine
+				OR = {
+					culture_group = byzantine
+					culture_group = iranian
+					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
+				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		upgrades_from = tb_culture_group_byzantine_1
@@ -2716,24 +2796,46 @@ tribal = {
 		desc = tb_culture_group_byzantine_1_desc
 		potential = {
 			OR = {
-				AND = {
-					culture_group = byzantine
-					NOT = { culture = coptic }
-				}
+				culture_group = byzantine
+				culture_group = iranian
+				culture = aromanian
+				culture = qashqai
+				culture = moghol
+				culture = brahui
 				has_building = tb_culture_group_byzantine_1
 				has_building = tb_culture_group_byzantine_2
 				has_building = tb_culture_group_byzantine_3
 			}
+			NOT = {culture = rumca}
+			NOT = {culture = alan}
 		}
 		is_active_trigger = {
 			ROOT = {
-				culture_group = byzantine
+				OR = {
+					culture_group = byzantine
+					culture_group = iranian
+					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
+				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 1
 			ROOT = {
-				culture_group = byzantine
+				OR = {
+					culture_group = byzantine
+					culture_group = iranian
+					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
+				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		upgrades_from = tb_culture_group_byzantine_2
@@ -2750,26 +2852,47 @@ tribal = {
 	tb_culture_group_byzantine_4 = {
 		desc = tb_culture_group_byzantine_1_desc
 		potential = {
-			OR = { 
-				AND = {
-					culture_group = byzantine
-					NOT = { culture = coptic }
-				}
+			OR = {
+				culture_group = byzantine
+				culture_group = iranian
+				culture = aromanian
+				culture = qashqai
+				culture = moghol
+				culture = brahui
 				has_building = tb_culture_group_byzantine_1
 				has_building = tb_culture_group_byzantine_2
 				has_building = tb_culture_group_byzantine_3
 				has_building = tb_culture_group_byzantine_4
 			}
+			NOT = {culture = rumca}
 		}
 		is_active_trigger = {
 			ROOT = {
-				culture_group = byzantine
+				OR = {
+					culture_group = byzantine
+					culture_group = iranian
+					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
+				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 1
 			ROOT = {
-				culture_group = byzantine
+				OR = {
+					culture_group = byzantine
+					culture_group = iranian
+					culture = aromanian
+					culture = qashqai
+					culture = moghol
+					culture = brahui
+				}
+				NOT = {culture = rumca}
+				NOT = {culture = alan}
 			}
 		}
 		upgrades_from = tb_culture_group_byzantine_3
@@ -3879,11 +4002,14 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				has_building = tb_culture_indian_1
 			}
+			Not = {culture = brahui}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -3894,10 +4020,13 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				}
+				Not = {culture = brahui}
 			}
 		}
 		trigger = { 
@@ -3910,10 +4039,13 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				}
+				Not = {culture = brahui}
 			}
 		}
 		
@@ -3935,12 +4067,15 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				has_building = tb_culture_indian_1
 				has_building = tb_culture_indian_2
 			}
+			Not = {culture = brahui}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -3951,10 +4086,13 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				}
+				Not = {culture = brahui}
 			}
 		}
 		trigger = { 
@@ -3967,10 +4105,13 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				}
+				Not = {culture = brahui}
 			}
 		}
 		upgrades_from = tb_culture_indian_1
@@ -3995,13 +4136,16 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				has_building = tb_culture_indian_1
 				has_building = tb_culture_indian_2
 				has_building = tb_culture_indian_3
 			}
+			Not = {culture = brahui}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -4012,10 +4156,13 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				}
+				Not = {culture = brahui}
 			}
 		}
 		trigger = { 
@@ -4028,10 +4175,13 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				}
+				Not = {culture = brahui}
 			}
 		}
 		upgrades_from = tb_culture_indian_2
@@ -4054,14 +4204,17 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				has_building = tb_culture_indian_1
 				has_building = tb_culture_indian_2
 				has_building = tb_culture_indian_3
 				has_building = tb_culture_indian_4
 			}
+			Not = {culture = brahui}
 		}
 		is_active_trigger = {
 			ROOT = {
@@ -4072,10 +4225,13 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				}
+				Not = {culture = brahui}
 			}
 		}
 		trigger = { 
@@ -4088,10 +4244,13 @@ tribal = {
 				culture_group = northern_indo_aryan_group
 				culture_group = southern_indo_aryan_group
 				culture_group = west_indo_aryan_group
-					culture_group = northern_dravidian_group
-					culture_group = eastern_dravidian_group
-					culture_group = southern_dravidian_group
+				culture_group = northern_dravidian_group
+				culture_group = eastern_dravidian_group
+				culture_group = southern_dravidian_group
+				culture = angrezi
+				culture_group = east_asian_group
 				}
+				Not = {culture = brahui}
 			}
 		}
 		upgrades_from = tb_culture_indian_3
@@ -4519,20 +4678,51 @@ tribal = {
 	tb_culture_tibetan_1 = {
 		desc = ca_culture_tibetan_desc
 		potential = {
-			OR = { 
+			OR = {
 				culture_group = tibetan_group
+				culture = shan		
+				culture_group = northern_indo_aryan_group	
+				culture_group = dardic
 				has_building = tb_culture_tibetan_1
+			}
+			NOT = {
+				OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+				}	
 			}
 		}
 		is_active_trigger = {
 			ROOT = {
-				culture_group = tibetan_group
+				OR = {
+					culture_group = tibetan_group
+					culture = shan		
+					culture_group = northern_indo_aryan_group	
+					culture_group = dardic				
+				}
+			}
+			NOT = {
+				OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+				}	
 			}
 		}
 		trigger = { 
 			TECH_CASTLE_CONSTRUCTION = 0 
 			ROOT = {
+				OR = { 
 				culture_group = tibetan_group
+				culture = shan		
+				culture_group = northern_indo_aryan_group	
+				culture_group = dardic	
+				}
+				NOT = {
+					OR  = {
+					culture = bhutanese
+					culture = low_bhutanese
+					}	
+				}
 			}
 		}
 
@@ -4552,21 +4742,52 @@ tribal = {
 	tb_culture_tibetan_2 = {
 		desc = ca_culture_tibetan_desc
 		potential = {
-			OR = { 
+			OR = {
 				culture_group = tibetan_group
+				culture = shan		
+				culture_group = northern_indo_aryan_group	
+				culture_group = dardic
 				has_building = tb_culture_tibetan_1
 				has_building = tb_culture_tibetan_2
+			}
+			NOT = {
+				OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+				}	
 			}
 		}
 		is_active_trigger = {
 			ROOT = {
-				culture_group = tibetan_group
+				OR = {
+					culture_group = tibetan_group
+					culture = shan		
+					culture_group = northern_indo_aryan_group	
+					culture_group = dardic				
+				}
+			}
+			NOT = {
+				OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+				}	
 			}
 		}
 		trigger = { 
-			TECH_CASTLE_CONSTRUCTION = 0 
+			TECH_CASTLE_CONSTRUCTION = 1 
 			ROOT = {
+				OR = { 
 				culture_group = tibetan_group
+				culture = shan		
+				culture_group = northern_indo_aryan_group	
+				culture_group = dardic	
+				}
+				NOT = {
+					OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+					}	
+				}
 			}
 		}
 		upgrades_from = tb_culture_tibetan_1
@@ -4588,22 +4809,53 @@ tribal = {
 	tb_culture_tibetan_3 = {
 		desc = ca_culture_tibetan_desc
 		potential = {
-			OR = { 
+			OR = {
 				culture_group = tibetan_group
+				culture = shan		
+				culture_group = northern_indo_aryan_group	
+				culture_group = dardic
 				has_building = tb_culture_tibetan_1
 				has_building = tb_culture_tibetan_2
 				has_building = tb_culture_tibetan_3
 			}
+			NOT = {
+				OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+				}	
+			}
 		}
 		is_active_trigger = {
 			ROOT = {
-				culture_group = tibetan_group
+				OR = {
+					culture_group = tibetan_group
+					culture = shan		
+					culture_group = northern_indo_aryan_group	
+					culture_group = dardic				
+				}
+			}
+			NOT = {
+				OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+				}	
 			}
 		}
 		trigger = { 
-			TECH_CASTLE_CONSTRUCTION = 1
+			TECH_CASTLE_CONSTRUCTION = 4
 			ROOT = {
+				OR = { 
 				culture_group = tibetan_group
+				culture = shan		
+				culture_group = northern_indo_aryan_group	
+				culture_group = dardic	
+				}
+				NOT = {
+					OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+					}	
+				}
 			}
 		}
 		upgrades_from = tb_culture_tibetan_2
@@ -4623,23 +4875,54 @@ tribal = {
 	tb_culture_tibetan_4 = {
 		desc = ca_culture_tibetan_desc
 		potential = {
-			OR = { 
+			OR = {
 				culture_group = tibetan_group
+				culture = shan		
+				culture_group = northern_indo_aryan_group	
+				culture_group = dardic
 				has_building = tb_culture_tibetan_1
 				has_building = tb_culture_tibetan_2
 				has_building = tb_culture_tibetan_3
 				has_building = tb_culture_tibetan_4
 			}
+			NOT = {
+				OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+				}	
+			}
 		}
 		is_active_trigger = {
 			ROOT = {
-				culture_group = tibetan_group
+				OR = {
+					culture_group = tibetan_group
+					culture = shan		
+					culture_group = northern_indo_aryan_group	
+					culture_group = dardic				
+				}
+			}
+			NOT = {
+				OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+				}	
 			}
 		}
 		trigger = { 
-			TECH_CASTLE_CONSTRUCTION = 1
+			TECH_CASTLE_CONSTRUCTION = 4
 			ROOT = {
+				OR = { 
 				culture_group = tibetan_group
+				culture = shan		
+				culture_group = northern_indo_aryan_group	
+				culture_group = dardic	
+				}
+				NOT = {
+					OR = {
+					culture = bhutanese
+					culture = low_bhutanese
+					}	
+				}
 			}
 		}
 		upgrades_from = tb_culture_tibetan_3
@@ -4997,6 +5280,180 @@ tribal = {
 		ai_creation_factor = 98
 		
 		convert_to_castle = ca_culture_siberian_2
+		
+		extra_tech_building_start = 0.8
+	}
+	#Caucasian Abreks
+	tb_culture_chechen_1 = {
+		desc = ca_culture_chechen_1_desc
+		potential = {
+			OR = {
+				culture_group = caucasian
+				culture_group = armenian_group
+				culture = alan
+				culture = balkar
+				has_building = tb_culture_chechen_1				
+			}
+		}
+		is_active_trigger = {
+			ROOT = {
+				OR = {
+					culture_group = caucasian
+					culture_group = armenian_group
+					culture = alan
+					culture = balkar
+				}
+			}
+		}
+		trigger = { 
+			TECH_CASTLE_CONSTRUCTION = 0 
+			ROOT = {
+				OR = {
+					culture_group = caucasian
+					culture_group = armenian_group
+					culture = alan
+					culture = balkar
+				}
+			}
+		}
+		prestige_cost = 100
+		build_time = 365
+		light_infantry = 15
+		light_infantry_defensive = 0.3
+		ai_creation_factor = 101
+		
+		extra_tech_building_start = 0.8
+	}
+	tb_culture_chechen_2 = {
+		desc = ca_culture_chechen_1_desc
+		potential = {
+			OR = {
+				culture_group = caucasian
+				culture_group = armenian_group
+				culture = alan
+				culture = balkar
+				has_building = tb_culture_chechen_1
+				has_building = tb_culture_chechen_2
+			}
+		}
+		is_active_trigger = {
+			ROOT = {
+				OR = {
+					culture_group = caucasian
+					culture_group = armenian_group
+					culture = alan
+					culture = balkar
+				}
+			}
+		}
+		trigger = { 
+			TECH_CASTLE_CONSTRUCTION = 0
+			ROOT = {
+				OR = {
+					culture_group = caucasian
+					culture_group = armenian_group
+					culture = alan
+					culture = balkar
+				}
+			}
+		}
+		upgrades_from = tb_culture_chechen_1
+		prestige_cost = 200
+		build_time = 547
+		light_infantry = 20
+		light_infantry_defensive = 0.3
+		ai_creation_factor = 100
+		
+		convert_to_castle = ca_culture_chechen_1
+		
+		extra_tech_building_start = 0.8
+	}
+	tb_culture_chechen_3 = {
+		desc = ca_culture_chechen_1_desc
+		potential = {
+			OR = {
+				culture_group = caucasian
+				culture_group = armenian_group
+				culture = alan
+				culture = balkar
+				has_building = tb_culture_chechen_1
+				has_building = tb_culture_chechen_2
+				has_building = tb_culture_chechen_3
+			}
+		}
+		is_active_trigger = {
+			ROOT = {
+				OR = {
+					culture_group = caucasian
+					culture_group = armenian_group
+					culture = alan
+					culture = balkar
+				}
+			}
+		}
+		trigger = { 
+			TECH_CASTLE_CONSTRUCTION = 1
+			ROOT = {
+				OR = {
+					culture_group = caucasian
+					culture_group = armenian_group
+					culture = alan
+					culture = balkar
+				}
+			}
+		}
+		upgrades_from = ca_culture_chechen_2
+		prestige_cost = 300
+		build_time = 730
+		light_infantry = 25
+		light_infantry_defensive = 0.3
+		ai_creation_factor = 99
+		
+		extra_tech_building_start = 0.8
+	}
+	tb_culture_chechen_4 = {
+		desc = ca_culture_chechen_1_desc
+		potential = {
+			OR = {
+				culture_group = caucasian
+				culture_group = armenian_group
+				culture = alan
+				culture = balkar
+				has_building = tb_culture_chechen_1
+				has_building = tb_culture_chechen_2
+				has_building = tb_culture_chechen_3
+				has_building = tb_culture_chechen_4
+			}
+		}
+		is_active_trigger = {
+			ROOT = {
+				OR = {
+					culture_group = caucasian
+					culture_group = armenian_group
+					culture = alan
+					culture = balkar
+				}
+			}
+		}
+		trigger = { 
+			TECH_CASTLE_CONSTRUCTION = 1
+			ROOT = {
+				OR = {
+					culture_group = caucasian
+					culture_group = armenian_group
+					culture = alan
+					culture = balkar
+				}
+			}
+		}
+		upgrades_from = tb_culture_chechen_3
+		prestige_cost = 400
+		build_time = 1095
+		light_infantry = 30
+		light_infantry_defensive = 0.3
+		ai_creation_factor = 98
+		
+		convert_to_castle = ca_culture_chechen_2
 		
 		extra_tech_building_start = 0.8
 	}

--- a/NEOW/common/retinue_subunits/00_retinue_subunits.txt
+++ b/NEOW/common/retinue_subunits/00_retinue_subunits.txt
@@ -398,12 +398,16 @@ RETTYPE_CUL_IRAN =
 	
 	potential = {
 		is_nomadic = no
-		OR = {
-			culture = khorasani
-			culture = hazar
-			culture = baloch
-			culture = persian
+		Or = {
+			culture_Group = iranian
+			culture = qashqai
+			culture = moghol
+			culture = brahui
 		}
+		Not = {culture = kurdish}
+		Not = {culture = tajik}
+		Not = {culture = afghan}
+		Not = {culture = alan}
 	}
 	
 	modifier = {
@@ -629,16 +633,15 @@ RETTYPE_CUL_JANISS =
 	
 	potential = {
 		is_nomadic = no
-		OR = {
-			culture = turkish
-			culture = elbistanli
-			culture = egeli
-			culture = kapadokyali
-			culture = karadenizci
-			culture = rumca
+		OR = { 
+				culture_group = oghuz
+				culture = rumca
+				has_building = ca_culture_turkish_1
+			}
+			Not = {culture = turkmen}
+			Not = {culture = azerbaijani}
+			Not = {culture = qashqai}
 		}
-	}
-	
 	modifier = {
 		heavy_infantry_offensive = 0.2
 		heavy_infantry_morale = 0.2
@@ -782,6 +785,7 @@ RETTYPE_CUL_CHECHEN =
 			culture_group = caucasian
 			culture_group = armenian_group
 		}
+		NOT = {culture - avar}
 	}
 	
 	modifier = {
@@ -799,6 +803,7 @@ RETTYPE_CUL_ATLANT =
 	potential = {
 		is_nomadic = no
 		culture = atlantian
+		culture = mandaeans
 	}
 	
 	modifier = {
@@ -1033,6 +1038,7 @@ RETTYPE_CUL_MONGOL =
 			culture_group = karluk
 			culture_group = mongolic
 		}
+		Not = {culture = moghol}
 	}
 	
 	modifier = {
@@ -1252,6 +1258,7 @@ RETTYPE_CUL_BALT =
 		OR = {
 			culture_group = baltic
 			culture_group = finno_ugric
+		Not = {Komi}
 		}
 	}
 	
@@ -1495,7 +1502,7 @@ RETTYPE_CUL_BYZ1 =
 		OR = {
 			culture = pontian
 			culture = griko
-			culture = cypriote					
+			culture = cypriote			
 		}
 	}
 	
@@ -1757,10 +1764,9 @@ RETTYPE_CUL_INDIAN =
 			culture_group = east_asian_group
 			culture = bhutanese
 			culture = low_bhutanese
+			culture = angrezi
 		}
-		NOR = {			
-			culture = domari
-		}
+		Not = {culture = brahai}
 	}
 	
 	modifier = {
@@ -2004,13 +2010,15 @@ RETTYPE_CUL_ASSYRIAN =
 		OR = {
 			culture = assyrian
 			culture = aramaic
-			culture = babylonian
+			culture = mandaeans
 		}
 	}
 	
 	modifier = {
 		heavy_infantry_defensive = 0.2
 		heavy_infantry_morale = 0.1
+		chariots_morale = 0.3
+		chariots_offensive = 0.3
 	}
 }
 
@@ -2572,7 +2580,6 @@ RETTYPE_CUL_SIBERIAN =
 			culture_group = yenisean
 			culture = komi
 		}
-		
 	}
 	
 	modifier = {

--- a/NEOW/localisation/NEOW_Misc_Loc.csv
+++ b/NEOW/localisation/NEOW_Misc_Loc.csv
@@ -1634,3 +1634,7 @@ tb_culture_swedish_2;Life Guard Camp;;;;;;;;;;;;;x;;;;;
 tb_culture_swedish_3;Life Guard Camp;;;;;;;;;;;;;x;;;;;
 tb_culture_swedish_4;Life Guard Camp;;;;;;;;;;;;;x;;;;;
 tb_culture_swedish_1_desc;While lacking necessary equipment of their more feudal counterparts, These warriors still uphold their duties of Life Guards. However these areas are sometime used to find hardened recruits for proper Life Guards. Hence these camps are established to be proving grounds with the benefit of blostering local forces.;;;;;;;;;;;;;x;;;;;
+tb_culture_chechen_1;Abrek Training Camp;;;;;;;;;;;;;x;;;;;
+tb_culture_chechen_2;Abrek Training Camp;;;;;;;;;;;;;x;;;;;
+tb_culture_chechen_3;Abrek Training Camp;;;;;;;;;;;;;x;;;;;
+tb_culture_chechen_4;Abrek Training Camp;;;;;;;;;;;;;x;;;;;


### PR DESCRIPTION
- Horse Archer building line changed.
Tool tip fixed
Some cultures lose it
Soitoskan now get it
Tribal line should work now
- Janissary retinue building finetuned
- Some Alan and Balkar get Aberk building line and there's now a tribal line for that.
- Oghur turks and Sazzac get Russian retinue building line
- Instead of Hussars, Domari get Arabic camels building line
- All Persian retinue changes
All Persian cultures except Alan get cataphracts along with the Qashqui, Moghol, and Brahui
Mention non-persian cultures above also get the persian retinue unit
Ditto for persian culture missing a retinue unit
- Middle eastern chariot retinue changes
Chariot unit now have morale bonus
Mandaeans get the building line now
- Fixed the Tibetan tribal building line
- Fixed Baltic-Finnish tribal retinue building line
- Fixed a typo in Scottish tribal
- Angrezi get Elephants